### PR TITLE
add package-lock.json to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+package-lock.js


### PR DESCRIPTION
I keep getting merge conflicts when I install dependencies, I wondered if it's okay to ignore the package-lock.json file